### PR TITLE
Add product list feature using FakeStore API

### DIFF
--- a/lib/bindings/product_binding.dart
+++ b/lib/bindings/product_binding.dart
@@ -1,0 +1,14 @@
+import 'package:dio/dio.dart';
+import 'package:get/get.dart';
+
+import '../controllers/product_controller.dart';
+import '../services/product_service.dart';
+
+class ProductBinding extends Bindings {
+  @override
+  void dependencies() {
+    final dio = Dio();
+    Get.lazyPut<ProductService>(() => ProductService(dio));
+    Get.lazyPut<ProductController>(() => ProductController());
+  }
+}

--- a/lib/controllers/product_controller.dart
+++ b/lib/controllers/product_controller.dart
@@ -1,0 +1,27 @@
+import 'package:get/get.dart';
+
+import '../models/product.dart';
+import '../services/product_service.dart';
+
+class ProductController extends GetxController {
+  final ProductService _service = Get.find<ProductService>();
+
+  final RxList<Product> products = <Product>[].obs;
+  final RxBool isLoading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    fetchProducts();
+  }
+
+  Future<void> fetchProducts() async {
+    try {
+      isLoading.value = true;
+      final result = await _service.getProducts();
+      products.assignAll(result);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import 'base_view.dart';
 import 'controllers/home_controller.dart';
+import 'routes/app_routes.dart';
 
 class HomeScreen extends BaseView<HomeController> {
   HomeScreen({super.key});
@@ -56,6 +57,11 @@ class HomeScreen extends BaseView<HomeController> {
                   padding: const EdgeInsets.symmetric(vertical: 16),
                 ),
                 child: const Text('Login', style: TextStyle(fontSize: 16)),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Get.toNamed(Routes.products),
+                child: const Text('View Products'),
               ),
             ],
           ),

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'product.g.dart';
+
+@JsonSerializable()
+class Product {
+  final int id;
+  final String title;
+  final String? description;
+  final String image;
+  final double price;
+
+  Product({
+    required this.id,
+    required this.title,
+    this.description,
+    required this.image,
+    required this.price,
+  });
+
+  factory Product.fromJson(Map<String, dynamic> json) => _$ProductFromJson(json);
+  Map<String, dynamic> toJson() => _$ProductToJson(this);
+}

--- a/lib/models/product.g.dart
+++ b/lib/models/product.g.dart
@@ -1,0 +1,17 @@
+part of 'product.dart';
+
+Product _$ProductFromJson(Map<String, dynamic> json) => Product(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      image: json['image'] as String,
+      price: (json['price'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$ProductToJson(Product instance) => <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'image': instance.image,
+      'price': instance.price,
+    };

--- a/lib/product_list_page.dart
+++ b/lib/product_list_page.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'base_view.dart';
+import 'controllers/product_controller.dart';
+
+class ProductListPage extends BaseView<ProductController> {
+  const ProductListPage({super.key});
+
+  @override
+  Widget buildView(BuildContext context, ProductController controller) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Products')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return ListView.builder(
+          itemCount: controller.products.length,
+          itemBuilder: (context, index) {
+            final product = controller.products[index];
+            return ListTile(
+              leading: Image.network(
+                product.image,
+                width: 40,
+                height: 40,
+                fit: BoxFit.cover,
+              ),
+              title: Text(product.title),
+              subtitle: Text('\$${product.price}'),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -2,8 +2,10 @@ import 'package:get/get.dart';
 
 import '../bindings/channel_list_binding.dart';
 import '../bindings/home_binding.dart';
+import '../bindings/product_binding.dart';
 import '../channel_list_screen.dart';
 import '../home_screen.dart';
+import '../product_list_page.dart';
 import 'app_routes.dart';
 
 class AppPages {
@@ -17,6 +19,11 @@ class AppPages {
       name: Routes.channels,
       page: () => const ChannelListScreen(),
       binding: ChannelListBinding(),
+    ),
+    GetPage(
+      name: Routes.products,
+      page: () => const ProductListPage(),
+      binding: ProductBinding(),
     ),
   ];
 }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,4 +1,5 @@
 abstract class Routes {
   static const home = '/';
   static const channels = '/channels';
+  static const products = '/products';
 }

--- a/lib/services/product_service.dart
+++ b/lib/services/product_service.dart
@@ -1,0 +1,14 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/product.dart';
+
+part 'product_service.g.dart';
+
+@RestApi(baseUrl: 'https://fakestoreapi.com')
+abstract class ProductService {
+  factory ProductService(Dio dio, {String baseUrl}) = _ProductService;
+
+  @GET('/products')
+  Future<List<Product>> getProducts();
+}

--- a/lib/services/product_service.g.dart
+++ b/lib/services/product_service.g.dart
@@ -1,0 +1,21 @@
+part of 'product_service.dart';
+
+class _ProductService implements ProductService {
+  _ProductService(this._dio, {this.baseUrl}) {
+    baseUrl ??= 'https://fakestoreapi.com';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<List<Product>> getProducts() async {
+    final response = await _dio.get<List<dynamic>>(
+      '$baseUrl/products',
+    );
+    return response.data!
+        .map((e) => Product.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,9 +19,15 @@ dependencies:
   path_provider: ^2.1.5
   app_badge_plus: ^1.2.3
   get: ^4.6.6
+  dio: ^5.4.0
+  retrofit: ^4.0.1
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.8
+  retrofit_generator: ^7.0.8
+  json_serializable: ^6.7.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add Dio/Retrofit dependencies and Product model
- implement ProductService with Retrofit and GetX controller/binding
- create product list page and route from home screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c6a297c888323a56cc8c98f68990f